### PR TITLE
(feat): document indexing

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -4,7 +4,7 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
 use std::sync::Arc;
 use crate::engine::IndexManager;
 
@@ -61,4 +61,35 @@ pub async fn delete_index(
 ) -> Result<Json<DeleteIndexResponse>, crate::error::EnzinError> {
     manager.delete_index(&name).await?;
     Ok(Json(DeleteIndexResponse { deleted: name }))
+}
+
+#[derive(Serialize)]
+pub struct IndexDocumentsResponse {
+    pub indexed: usize,
+}
+
+pub async fn index_documents(
+    State(manager): State<Arc<IndexManager>>,
+    Path(name): Path<String>,
+    body: String,
+) -> Result<(StatusCode, Json<IndexDocumentsResponse>), crate::error::EnzinError> {
+    let parsed: Value = serde_json::from_str(&body)
+        .map_err(|e| crate::error::EnzinError::InvalidDocument(format!("invalid json: {}", e)))?;
+
+    let documents = match parsed {
+        Value::Array(arr) => arr,
+        Value::Object(_) => vec![parsed],
+        _ => {
+            return Err(crate::error::EnzinError::InvalidDocument(
+                "expected object or array of objects".to_string(),
+            ))
+        }
+    };
+
+    let count = manager.index_documents(&name, documents).await?;
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(IndexDocumentsResponse { indexed: count }),
+    ))
 }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -12,5 +12,6 @@ pub fn create_routes(manager: Arc<IndexManager>) -> Router {
         .route("/indexes", post(handlers::create_index))
         .route("/indexes", get(handlers::list_indexes))
         .route("/indexes/:name", delete(handlers::delete_index))
+        .route("/indexes/:name/documents", post(handlers::index_documents))
         .with_state(manager)
 }

--- a/src/engine/index.rs
+++ b/src/engine/index.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use serde_json::Value;
 use tantivy::{Index, schema::Schema};
 use tokio::sync::RwLock;
 use crate::error::EnzinError;
+use super::schema::infer_schema_from_document;
 
 pub struct IndexManager {
     indexes: Arc<RwLock<HashMap<String, Index>>>,
@@ -40,6 +42,38 @@ impl IndexManager {
         Ok(())
     }
 
+    pub async fn init_schema_from_document(
+        &self,
+        index_name: &str,
+        doc: &Value,
+    ) -> Result<(), EnzinError> {
+        let index = self.get_index(index_name).await?;
+        let current_schema = index.schema();
+
+        if current_schema.fields().count() > 0 {
+            return Ok(());
+        }
+
+        let new_schema = infer_schema_from_document(doc)
+            .map_err(|e| EnzinError::InvalidDocument(e))?;
+
+        let index_path = self.data_dir.join(index_name);
+        
+        std::fs::remove_dir_all(&index_path)
+            .map_err(|e| EnzinError::InternalError(format!("failed to remove old index: {}", e)))?;
+        
+        std::fs::create_dir_all(&index_path)
+            .map_err(|e| EnzinError::InternalError(format!("failed to create index dir: {}", e)))?;
+
+        let new_index = Index::create_in_dir(&index_path, new_schema)
+            .map_err(|e| EnzinError::InternalError(format!("failed to create index: {}", e)))?;
+
+        let mut indexes = self.indexes.write().await;
+        indexes.insert(index_name.to_string(), new_index);
+
+        Ok(())
+    }
+
     pub async fn list_indexes(&self) -> Vec<String> {
         let indexes = self.indexes.read().await;
         indexes.keys().cloned().collect()
@@ -71,6 +105,74 @@ impl IndexManager {
             .get(name)
             .cloned()
             .ok_or_else(|| EnzinError::IndexNotFound(format!("index '{}' not found", name)))
+    }
+
+    pub async fn index_documents(
+        &self,
+        index_name: &str,
+        documents: Vec<Value>,
+    ) -> Result<usize, EnzinError> {
+        if documents.is_empty() {
+            return Err(EnzinError::InvalidDocument(
+                "no documents provided".to_string(),
+            ));
+        }
+
+        self.init_schema_from_document(index_name, &documents[0])
+            .await?;
+
+        let index = self.get_index(index_name).await?;
+
+        let mut writer = index
+            .writer(50_000_000)
+            .map_err(|e| EnzinError::InternalError(format!("failed to create writer: {}", e)))?;
+
+        let schema = index.schema();
+        let mut indexed_count = 0;
+
+        for doc in documents {
+            let mut tantivy_doc = tantivy::doc!();
+
+            match doc.as_object() {
+                Some(obj) => {
+                    for (key, value) in obj.iter() {
+                        if let Ok(field) = schema.get_field(key) {
+                            match value {
+                                Value::String(s) => {
+                                    tantivy_doc.add_text(field, s.clone());
+                                }
+                                Value::Number(n) => {
+                                    if let Some(u) = n.as_u64() {
+                                        tantivy_doc.add_u64(field, u);
+                                    }
+                                }
+                                Value::Bool(b) => {
+                                    tantivy_doc.add_u64(field, if *b { 1 } else { 0 });
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    writer
+                        .add_document(tantivy_doc)
+                        .map_err(|e| {
+                            EnzinError::InternalError(format!("failed to add document: {}", e))
+                        })?;
+                    indexed_count += 1;
+                }
+                None => {
+                    return Err(EnzinError::InvalidDocument(
+                        "document must be a json object".to_string(),
+                    ))
+                }
+            }
+        }
+
+        writer
+            .commit()
+            .map_err(|e| EnzinError::InternalError(format!("failed to commit: {}", e)))?;
+
+        Ok(indexed_count)
     }
 }
 
@@ -142,6 +244,69 @@ mod tests {
         let manager = IndexManager::new(temp_dir.path().to_path_buf());
 
         let result = manager.get_index("nonexistent").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_index_documents_single() {
+        use serde_json::json;
+        
+        let temp_dir = TempDir::new().unwrap();
+        let manager = IndexManager::new(temp_dir.path().to_path_buf());
+
+        manager.create_index("test").await.unwrap();
+        
+        let docs = vec![json!({
+            "title": "hello",
+            "count": 42
+        })];
+        
+        let result = manager.index_documents("test", docs).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_index_documents_batch() {
+        use serde_json::json;
+        
+        let temp_dir = TempDir::new().unwrap();
+        let manager = IndexManager::new(temp_dir.path().to_path_buf());
+
+        manager.create_index("test").await.unwrap();
+        
+        let docs = vec![
+            json!({ "title": "first" }),
+            json!({ "title": "second" }),
+            json!({ "title": "third" }),
+        ];
+        
+        let result = manager.index_documents("test", docs).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_index_documents_empty() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = IndexManager::new(temp_dir.path().to_path_buf());
+
+        manager.create_index("test").await.unwrap();
+        
+        let docs = vec![];
+        let result = manager.index_documents("test", docs).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_index_documents_nonexistent_index() {
+        use serde_json::json;
+        
+        let temp_dir = TempDir::new().unwrap();
+        let manager = IndexManager::new(temp_dir.path().to_path_buf());
+
+        let docs = vec![json!({ "title": "test" })];
+        let result = manager.index_documents("nonexistent", docs).await;
         assert!(result.is_err());
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,3 +1,4 @@
 pub mod index;
+pub mod schema;
 
 pub use index::IndexManager;

--- a/src/engine/schema.rs
+++ b/src/engine/schema.rs
@@ -1,0 +1,81 @@
+use serde_json::Value;
+use tantivy::schema::{Schema, STORED, TEXT};
+
+pub fn infer_schema_from_document(doc: &Value) -> Result<Schema, String> {
+    let mut schema_builder = Schema::builder();
+
+    match doc.as_object() {
+        Some(obj) => {
+            for (key, value) in obj.iter() {
+                match value {
+                    Value::String(_) => {
+                        schema_builder.add_text_field(key, TEXT | STORED);
+                    }
+                    Value::Number(_) => {
+                        schema_builder.add_u64_field(key, STORED);
+                    }
+                    Value::Bool(_) => {
+                        schema_builder.add_u64_field(key, STORED);
+                    }
+                    _ => {
+                        return Err(format!("unsupported field type for '{}'", key));
+                    }
+                }
+            }
+            Ok(schema_builder.build())
+        }
+        None => Err("document must be a json object".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_infer_string_field() {
+        let doc = json!({ "title": "test" });
+        let schema = infer_schema_from_document(&doc).unwrap();
+        assert_eq!(schema.fields().count(), 1);
+    }
+
+    #[test]
+    fn test_infer_number_field() {
+        let doc = json!({ "count": 42 });
+        let schema = infer_schema_from_document(&doc).unwrap();
+        assert_eq!(schema.fields().count(), 1);
+    }
+
+    #[test]
+    fn test_infer_bool_field() {
+        let doc = json!({ "active": true });
+        let schema = infer_schema_from_document(&doc).unwrap();
+        assert_eq!(schema.fields().count(), 1);
+    }
+
+    #[test]
+    fn test_infer_mixed_schema() {
+        let doc = json!({
+            "title": "test",
+            "count": 42,
+            "active": true
+        });
+        let schema = infer_schema_from_document(&doc).unwrap();
+        assert_eq!(schema.fields().count(), 3);
+    }
+
+    #[test]
+    fn test_infer_unsupported_type() {
+        let doc = json!({ "data": [1, 2, 3] });
+        let result = infer_schema_from_document(&doc);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_infer_non_object() {
+        let doc = json!([1, 2, 3]);
+        let result = infer_schema_from_document(&doc);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
closes: https://github.com/emalinegayhart/enzin/issues/10

added dynamic schema inference from json documents. supports single and batch document indexing with automatic schema initialization on first document. includes 10 unit tests for schema inference and document indexing.