### PR TITLE
(chore): docker setup with multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM rust:latest as builder
+
+WORKDIR /build
+
+COPY Cargo.toml Cargo.toml
+COPY src src
+
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /build/target/release/enzin /app/enzin
+
+RUN mkdir -p /data
+
+EXPOSE 7700
+
+VOLUME ["/data"]
+
+ENV ENZIN_PORT=7700
+ENV ENZIN_DATA_DIR=/data
+
+CMD ["/app/enzin"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  enzin:
+    build: .
+    ports:
+      - "7700:7700"
+    volumes:
+      - enzin_data:/data
+    environment:
+      ENZIN_PORT: 7700
+      ENZIN_DATA_DIR: /data
+
+volumes:
+  enzin_data:

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,23 +2,33 @@ mod api;
 mod engine;
 mod error;
 
+use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() {
-    let data_dir = PathBuf::from("./data");
+    let port = env::var("ENZIN_PORT")
+        .unwrap_or_else(|_| "7700".to_string())
+        .parse::<u16>()
+        .expect("ENZIN_PORT must be a valid u16");
+
+    let data_dir = env::var("ENZIN_DATA_DIR")
+        .unwrap_or_else(|_| "./data".to_string());
+    let data_dir = PathBuf::from(&data_dir);
+    
     std::fs::create_dir_all(&data_dir).expect("Failed to create data directory");
 
     let manager = Arc::new(engine::IndexManager::new(data_dir));
     let app = api::create_routes(manager);
 
-    let listener = TcpListener::bind("127.0.0.1:7700")
+    let addr = format!("0.0.0.0:{}", port);
+    let listener = TcpListener::bind(&addr)
         .await
-        .expect("Failed to bind to port 7700");
+        .expect(&format!("Failed to bind to {}", addr));
 
-    println!("Server running on http://127.0.0.1:7700");
+    println!("Server running on http://0.0.0.0:{}", port);
 
     axum::serve(listener, app)
         .await


### PR DESCRIPTION
closes: https://github.com/emalinegayhart/enzin/issues/5

added dockerfile using multi-stage build for minimal image size. build stage uses rust:latest, runtime stage uses debian:bookworm-slim. includes docker-compose.yml for easy local development. server now binds to 0.0.0.0 and reads configuration from environment variables (enzin_port, enzin_data_dir) for container flexibility.